### PR TITLE
feat(slug): use slug read from db, or generate if absent. Preserve legacy slugs.

### DIFF
--- a/src/main/kotlin/mixit/util/Extensions.kt
+++ b/src/main/kotlin/mixit/util/Extensions.kt
@@ -106,6 +106,7 @@ fun String.toSlug() =
                 .replace("[^a-z\\d\\s]".toRegex(), " ")
                 .split(" ")
                 .joinToString("-")
+                .replace("-+".toRegex(), "-")   // Avoid multiple consecutive "--"
 
 fun <T> Iterable<T>.shuffle(): Iterable<T> =
         toMutableList().apply { Collections.shuffle(this) }

--- a/src/main/kotlin/mixit/web/handler/BlogHandler.kt
+++ b/src/main/kotlin/mixit/web/handler/BlogHandler.kt
@@ -51,7 +51,7 @@ private class PostDto(
 
 private fun Post.toDto(author: User, language: Language, markdownConverter: MarkdownConverter) = PostDto(
         id,
-        slug[language] ?: "",
+        slug[language] ?: title[language]?.toSlug() ?: "",
         author,
         addedAt.format(language),
         title[language] ?: "",

--- a/src/main/resources/data/blog.json
+++ b/src/main/resources/data/blog.json
@@ -20,6 +20,10 @@
         "title": {
             "ENGLISH": "Teams, products, pedagogy and design talks at MiXiT 2017",
             "FRENCH": "Talks équipe, produit, pédagogie et design à MiXiT 2017"
+        },
+        "slug": {
+            "ENGLISH": "teams--products--pedagogy-and-design-talks-at-mixit-2017",
+            "FRENCH": "talks-equipe--produit--pedagogie-et-design-a-mixit-2017"
         }
     },{
         "addedAt": [
@@ -123,7 +127,11 @@
       "title": {
           "ENGLISH": "MiXiT 2017 ticketing: pre-registration",
           "FRENCH": "Billetterie MiXiT 2017 : pré-inscription"
-      }
+      },
+        "slug": {
+            "ENGLISH": "mixit-2017-ticketing--pre-registration",
+            "FRENCH": "billetterie-mixit-2017---pre-inscription"
+        }
     },
     {
         "addedAt": [

--- a/src/test/kotlin/mixit/util/ExtensionsTest.kt
+++ b/src/test/kotlin/mixit/util/ExtensionsTest.kt
@@ -1,0 +1,20 @@
+package mixit.util
+
+import org.junit.Test
+
+import org.junit.Assert.*
+
+/**
+ * Unit tests for Extensions
+ */
+class ExtensionsTest {
+
+    @Test
+    fun toSlug() {
+        assertEquals("", "".toSlug())
+        assertEquals("-", "---".toSlug())
+        assertEquals("billetterie-mixit-2017-pre-inscription", "Billetterie MiXiT 2017 : pré-inscription".toSlug())
+        assertEquals("mixit-2017-ticketing-pre-registration", "MiXiT 2017 ticketing: pre-registration".toSlug())
+    }
+
+}


### PR DESCRIPTION
Fix #157.