### PR TITLE
Update speaker info

### DIFF
--- a/src/main/resources/data/talks_2017.json
+++ b/src/main/resources/data/talks_2017.json
@@ -1741,5 +1741,53 @@
       13,
       40
     ]
+  },
+  {
+    "event": "mixit17",
+    "title": "Trouvez vos cadences, et faite un pas vers le Continuous Delivery.",
+    "summary": "Cette session vous emmènera à la découverte de la notion de **cadence**,  celle qui rythme les activités des équipes, quelle que soit l’approche utilisée, du cycle en V au continous delivery en passant par Scrum et Kanban.\n\n La compréhension des cadences apporte des éléments de réponse aux questions suivantes (entre autres) :\n\n* Faut-il caler la production des user stories sur le calendrier des sprints, sur le release plan ? Y a-t-il d’autres possibilités intéressantes à explorer ? \n* Comment et quand intégrer les différents types de test au flux des travaux ?\n* À quel rythme faut-il livrer en production ? La question se pose-t-elle encore si vous utilisez une approche “continuous delivery” ?\n* Vous devez déjà avoir entendu parlé du fameux “rythme soutenable” nécessaire à la réussite d’un projet agile dans la durée. En théorie c’est très simple, mais en pratique, comment déterminer ce fameux rythme ?\n\nEt il y en a même qui pensent qu’avec de bonnes cadences on peut fluidifier l’ensemble des travaux à réaliser, de la collecte des besoins jusqu’au déploiement, s’affranchir des itérations et réussir un passage au Continuous Delivery !!",
+    "speakerIds": ["anne.gabrillagues"],
+    "language": "FRENCH",
+    "topic": "Ops",
+    "format": "TALK",
+    "room": "UNKNOWN",
+    "start": null,
+    "end": null
+  },
+  {
+    "event": "mixit17",
+    "title": "Legacy Club",
+    "summary": "Code non maintenable, bugs à répétition, corrections chronophages, moral dans les chaussettes... Pas étonnant que la plupart d’entre nous préfèrent travailler sur des projets où tout est à (re)construire (Greenfield) plutôt que sur du code Legacy (Brownfield). Il faut dire que le Legacy sur lequel on a perdu le contrôle est plus que pénible. C’est épuisant, voire décourageant. Et si nous nous trompions ? __Et si – munis de quelques techniques de refactoring et de communication- nous pouvions inverser les choses et reprendre le contrôle…__ \n\n__Le temps d’une session avec des bouts de live-coding__, venez découvrir les trucs et astuces des gens qui préfèrent reprendre le contrôle plutôt que de subir. Voire qui préfèrent les opportunités cachées du Legacy aux pages blanches des projets Greenfield. Vous aussi, rejoignez le Legacy Club !",
+    "speakerIds": ["tpierrain", "bruno.boucard"],
+    "language": "FRENCH",
+    "topic": "Dev",
+    "format": "TALK",
+    "room": "UNKNOWN",
+    "start": null,
+    "end": null
+  },
+  {
+    "event": "mixit17",
+    "title": "Notes on Type Theory for absolute beginners",
+    "summary": "One important subject we analyse in languages is its type system. Having a general overview of a type system provides information about the language structure, possible optimisations and may help us to understand how statements are evaluated. Those are topics that we shall consider for when creating a new project. This talk will provide a gentle introduction to type theory, explaining step by step how we transform source code into logical statements. \nTopics we will cover: \n* Why Type Theory? \n* Quick introduction to logic\n * Where are those concepts used? \n* An analysis of Java Type System",
+    "speakerIds": ["hanneli.tavante"],
+    "language": "ENGLISH",
+    "topic": "Dev",
+    "format": "WORKSHOP",
+    "room": "UNKNOWN",
+    "start": null,
+    "end": null
+  },
+  {
+    "event": "mixit17",
+    "title": "CTF : Sortez le Mr Robot qui est en vous !",
+    "summary": "Vous avez déjà entendu parler de SQL Injection, de failles CSRF ou autres ? Ok, mais les avez-vous déjà exploitées ?\n\nDans ce workshop, nous vous proposerons un \"Capture The Flag\" qui vous permettra de chercher, analyser et exploiter différentes failles de sécurité. Que vous soyez novice ou non, ne vous inquiétez pas, nous serons là pour vous aiguiller dans le seul but d'apprendre des choses tout en passant un excellent moment !\n\nCe workshop se déroulera en plusieurs temps :\n- D'abord un tour d'horizon de différentes failles, avec des exemples concrets mettant en évidence que même les meilleurs développeurs du monde font des erreurs :)\n- Ensuite, nous vous fournirons des liens vers différentes applications dont le but sera d'exploiter une faille vous permettant de récupérer un code.\n- Chaque code récupéré vous permettra de gagner un nombre de points dépendant de la difficulté.\n- Les plus chevronnés d'entre vous seront récompensés :)\n\nNotre rêve caché : trouver le Mr Robot de ce mix-it !",
+    "speakerIds": ["mickaeljeanroy"],
+    "language": "FRENCH",
+    "topic": "Dev",
+    "format": "WORKSHOP",
+    "room": "UNKNOWN",
+    "start": null,
+    "end": null
   }
 ]

--- a/src/main/resources/data/talks_2017.json
+++ b/src/main/resources/data/talks_2017.json
@@ -217,11 +217,11 @@
   },
   {
     "event": "mixit17",
-    "title": "D\u00e9velopper une application de pari en ligne avec la blockchain Ethereum",
-    "summary": "Dans ce codelab, nous commencerons par une pr\u00e9sentation de la blockchain Ethereum et du principe des smart-contracts. \n\nPuis nous d\u00e9velopperons une Dapp (application compos\u00e9e d\u2019un smart contract en backend + une ihm) basique de pari en ligne sur Ethereum en utilisant le framework Truffle et Angular2.\n\nCela permettra d'apprendre : \n\n\u2022 \u00e0 cr\u00e9er et tester unitairement un smart contract, \n\n\u2022 \u00e0 interfacer ce smart contract avec une IHM Web en Angular2 et Metamask (noeud Ethereum tr\u00e8s light sous forme de plugin Chrome). \n\nDes connaissances du fonctionnement des concepts g\u00e9n\u00e9raux des blockchains sont fortement conseill\u00e9es pour ce codelab, m\u00eame si il y aura quelques rappels au d\u00e9but. \n\nPar contre, pas besoin de conna\u00eetre Ethereum, et la partie Angular2 sera fournie dans les grandes lignes aux participants",
-    "speakerIds": ["benjamin.fontaine", "françois.kha"],
+    "title": "Jouer et gagner en programmant une blockchain avec Ethereum et Docker",
+    "summary": "Peu connus avant le succès de la cryptomonnaie \"BitCoin\", la technologie **blockchain** et le concept de \"**smart contracts**\" ont maintenant commencé à tracer leur chemin. De nouvelles formes d'organisations distribuées font leur apparition. Et de grandes entreprises, embarquées actuellement dans une phase de numérisation intensive de leurs activités, regardent maintenant avec attention comment exploiter la blockchain, qui pourrait devenir un nouveau modèle disruptif de leurs relations économiques, financières, contractuelles, organisationnelles et de fonctionnement.\n\nAprès une introduction rapide du concept et de la technologie sous-jacente, et de la notion d'application décentralisée, nous vous proposons un **atelier pour apprendre à programmer une solution blockchain**, en s'appuyant sur le framework et l'environnement le plus en vogue du moment : **[Ethereum](https://www.ethereum.org/)**.\n\nVenez donc programmer un jeu simple, de façon décentralisée. A la fin de la séance, vous serez reliés à tous les autres participants au sein de la même blockchain pour participer au jeu de manière collective.\n\nVous apprendrez à :\n* Comprendre les notions de base d'Ethereum.\n* Exécuter les commandes Ethereum dans un conteneur (ici [Docker](https://www.docker.com/)).\n* Créer un compte et une blockchain de test, démarrer un noeud et miner la blockchain.\n* Programmer un \"smart-contract\" en langage [Solidity](http://solidity.readthedocs.io).\n* Intégrer un \"smart-contract\" dans une application décentralisée (Dapp) en JavaScript.\n\n*Pré-requis : ordinateur portable équipé avec VirtualBox v5 et si possible Vagrant (une image de machine virtuelle, comportant tout le matériel nécessaire, sera fournie en séance).*",
+    "speakerIds": ["philippe.bazart", "112455790095465496145"],
     "language": "FRENCH",
-    "topic": "Alien",
+    "topic": "Dev",
     "format": "WORKSHOP",
     "room": "UNKNOWN",
     "start": [


### PR DESCRIPTION
Resolves parts of the issue https://github.com/mixitconf/mixit/issues/178

- [x] Mettre à jour tous les titres et descriptions avec export

Ajouter les horaires:
- [ ] Paccard
- [ ] Lobbies/sabatier
- [ ] Trouvez vos cadences/gabrillargues
- [ ] Legacy club/pierrain
- [ ] Type theory/tavante ?
- [ ] Mr Robot/jeanroy

Manque les talks:
- [x] trouvez vos cadences/gabrillargues
- [x] legacy club/pierrain
- [x] manque type theory/tavante ?

Workshops:
- [x] manque Mr Robot/jeanroy
- [x] remplacer ethereum (co-speaker cflamens)

Keynotes:
- [ ] Nety et Mila
- [ ] Qwant
- [ ] Regen villages
- [ ] Alain renaud
- [ ] Gonette

Horaires:
- [ ] décaler les 2 journées de 10 minutes
- [ ] insérer mini keynote 10 minutes Gonette
- [ ] prendre en compte les nouvelles contraintes speakers de [Trello](https://trello.com/c/rsPUdiPH/167-planning-contraintes-non-traitees) et [gdoc](https://docs.google.com/spreadsheets/d/1nvWTJ2Xr0QE9OcDH58WTX7QQQlwNFtZ65ogkDIjlueU/edit#gid=0)

Random:
- [ ] mettre le bon jour

Challenge:
- [ ] hexagon challenge a faire figurer tout une journée (laquelle?)...
