### PR TITLE
fix failing test on staff number count

### DIFF
--- a/src/test/kotlin/mixit/integration/UserIntegrationTests.kt
+++ b/src/test/kotlin/mixit/integration/UserIntegrationTests.kt
@@ -49,7 +49,7 @@ class UserIntegrationTests(@Autowired val client: WebTestClient) {
                 .exchange()
                 .expectStatus().is2xxSuccessful
                 .expectBodyList<User>()
-                .hasSize(11)
+                .hasSize(12)
     }
 
     @Test


### PR DESCRIPTION
Naive fix to make build ~~great~~ green again.

A more robust solution would be better to avoid breaking this test newt time we add a staff member.