### PR TITLE
Fix ticketing deadline for 2022

### DIFF
--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -51,7 +51,7 @@ home.wrapper.title=The conference from Lyon with crêpes and love
 home.wrapper.text=The conference <span class="mxt-text--cyan">from Lyon</span> <br>with crêpes and <span class="mxt-text--orange">love</span>
 home.wrapper.dates=May 24 &amp; 25, 2022
 home.wrapper.submit=Ticketing access
-home.wrapper.submit.text=Try your luck until March 5 at midnight
+home.wrapper.submit.text=Try your luck until March 31 at midnight
 home.wrapper.participate=Come to MiXiT
 home.topics.title=Topics
 home.topics.science.title=Science
@@ -389,7 +389,7 @@ ticketing.error.back=Back to the form
 ticketing.closed.text=Registration is now closed. If, unfortunately, you don't have a ticket, keep in mind you will be able to watch recording of the sessions on vimeo!
 ticketing.soon.text=Registration will open soon... stay tuned !
 ticketing.description.why=Why do you need to pre-register ?
-ticketing.description.intro=We know that it has become difficult to acquire the precious pass that opens the gates of this conference. Each year more and more attendees would like to join, and we are extremely thankful for that, but as a result not everyone can get a ticket. This year, as we did previously, no need for you to be stressed out, we are opening a pre-register step for everybody for <b>3 full weeks (until March, 5, midnight)</b>. 
+ticketing.description.intro=We know that it has become difficult to acquire the precious pass that opens the gates of this conference. Each year more and more attendees would like to join, and we are extremely thankful for that, but as a result not everyone can get a ticket. This year, as we did previously, no need for you to be stressed out, we are opening a pre-register step for everybody for <b>one month (until March, 31, midnight)</b>. 
 ticketing.description.how=Then, we are going to do what every conference overwhelmed by its own popularity does (Google IO, Apple WWDC, NgConf, and... MiXiT): we are going to distribute the tickets among those who pre-registered with a good old random(). The lucky ones (most of you) will receive a link to buy their ticket. The less lucky ones will be able to catch up with the session recordings less than a week after the conference.
 ticketing.description.hack=I already see some of you thinking about registering several times with their different email addresses, but we will take a close look, and <b>the ones who get caught will be excluded from the process.</b> If you want to check your subscription, you can log in on our website with the same email address used for pre-registering step. You can see on your profile page the state of your pre-registration.
 ticketing.description.plus=One last thing: to ensure fairness among everybody, if you don't want to use your link to buy a ticket, we will give it to someone else. We won't authorize a transfer: the buyer of the ticket must have the same email used for the pre-registering step.

--- a/src/main/resources/messages_fr.properties
+++ b/src/main/resources/messages_fr.properties
@@ -53,7 +53,7 @@ home.wrapper.text=La conférence <span class="mxt-text--cyan">Lyonnaise</span> <
 home.wrapper.dates=24 &amp; 25 mai 2022
 
 home.wrapper.submit=Accès à la billeterie
-home.wrapper.submit.text=Tentez votre chance jusqu'au 05 mars minuit
+home.wrapper.submit.text=Tentez votre chance jusqu'au 31 mars minuit
 home.wrapper.participate=Participer à MiXiT
 home.topics.title=Catégories
 home.topics.science.title=Science
@@ -354,7 +354,7 @@ ticketing.error.back=Retour vers le formulaire
 ticketing.closed.text=La billetterie est maintenant fermée, si tu n'as pas pu avoir un billet rendez-vous l'année prochaine.
 ticketing.soon.text=La billeterie va bientôt être mise en place... On vous tient au courant !
 ticketing.description.why=Pourquoi avoir mis en place une loterie ?
-ticketing.description.intro=Il est devenu difficile d'acquérir le précieux sésame qui vous ouvrira les portes de la conférence MiXiT. Chaque année vous êtes de plus en plus nombreux à vouloir venir mais le nombre de place est limité. Mais cette année comme l'année passée, pas de stress pour tenter d'avoir votre place, nous ouvrons un pré-enregistrement à tout le monde <b>pendant 3 semaines (jusqu’au jeudi 5 mars minuit)</b>. Tu prends 5 minutes quand tu as le temps, tu entres ton nom, prénom et email.
+ticketing.description.intro=Il est devenu difficile d'acquérir le précieux sésame qui vous ouvrira les portes de la conférence MiXiT. Chaque année vous êtes de plus en plus nombreux à vouloir venir mais le nombre de place est limité. Mais cette année comme l'année passée, pas de stress pour tenter d'avoir votre place, nous ouvrons un pré-enregistrement à tout le monde <b>pendant un mois (jusqu’au jeudi 31 mars minuit)</b>. Tu prends 5 minutes quand tu as le temps, tu entres ton nom, prénom et email.
 ticketing.description.how=Ensuite, cela se passera comme cela se passe dans nombre de conférences dépassées par leur popularité (Google IO, Apple WWDC, NgConf, et... MiXiT) : on distribuera les places parmi les pré-inscrits avec un random(). Les heureux choisis (la plupart d’entre vous) recevront alors un lien pour acheter leur place. Les moins chanceux pourront se rattraper avec les vidéos des conférences.
 ticketing.description.hack=Je te vois penser te pré-inscrire plusieurs fois avec toutes tes adresses hotmail et caramail, mais sache que l'on va contrôler tout ça, et que <b>toute personne qui tentera ce genre de manœuvre se verra exclue sans possibilité de recours.</b> Si tu n'es pas sûr d'être inscrit, tu peux te connecter sur le site avec la même adresse email utilisée pour le préenregistrement et tu peux contôler ton inscription dans ta page profil. 
 ticketing.description.plus=Autre détail non négligeable, pour conserver une équité entre tous les participants, si tu ne souhaites pas garder ton sésame pour l'achat d'une place, elle sera remise en jeu. Nous n'autoriserons pas de transfert : l'acheteur devra avoir le même email au pré-enregistrement et sur la billetterie.


### PR DESCRIPTION
https://mixitconf.org/ says the ticketing is open until March 31.
But, https://mixitconf.org/ticketing says it is until March 5. I suppose it's the deadline of a previous year, that has not been updated.

This PR should fix that, and also says people have one month (instead of 3 weeks)

Disclaimer: I did not test, shame on me, but I only changed the ResourceBundles