### PR TITLE
fix(blog): images with max-size and some margins

### DIFF
--- a/src/main/resources/templates/post.mustache
+++ b/src/main/resources/templates/post.mustache
@@ -5,7 +5,7 @@
     <p class="text-center subheader mxt-text--page-title">{{#i18n}}blog.by{{/i18n}} <strong>{{post.author.firstname}}</strong>, {{#i18n}}blog.on{{/i18n}} <strong>{{post.addedAt}}</strong></p><br />
 </div>
 
-<div class="container mxt-wrapper--page-content">
+<div class="container mxt-wrapper--page-content mxt-blog">
     <p>{{#markdown}}{{post.headline}}{{/markdown}}</p>
     {{#post.content}}
     <hr />

--- a/src/main/sass/mixit.scss
+++ b/src/main/sass/mixit.scss
@@ -536,3 +536,10 @@ h3 {
   padding-bottom: 1rem;
   padding-top: 1rem;
 }
+
+.mxt-blog {
+    img {
+        max-width: 100%;
+        margin-bottom: 1em;
+    }
+}


### PR DESCRIPTION
Large images on blog posts are not restricted in size:
<img alt="image" src="https://user-images.githubusercontent.com/750715/166813773-136dd0b2-761d-42ed-ac90-92bfccfb8c26.png">

Also, the markdown content is scrapped from any styling injection: cannot define inline styles on images in markdown, any style is removed where rendered.

Then add some default CSS on every images on blog post.